### PR TITLE
Fix #7 Hide selected hero during picking phase

### DIFF
--- a/content/dota_addons/junglenational/panorama/scripts/custom_game/hero_selection.js
+++ b/content/dota_addons/junglenational/panorama/scripts/custom_game/hero_selection.js
@@ -195,7 +195,7 @@ function LoadPlayers() {
  * swap to the hero preview screen. */
 function PlayerPicked( player, hero ) {
 	//Update the player panel
-	playerPanels[player].SetHero( hero );
+	//playerPanels[player].SetHero( hero );
 
 	//Disable the hero button
 	//$('#'+hero).AddClass( "taken" );


### PR DESCRIPTION
Playerpanels are still created, so we still show the avatars. However, when someone picks a hero, we don't show the pick anymore
